### PR TITLE
Implement Compiler Wrapper

### DIFF
--- a/Compiler/Compiler.csproj
+++ b/Compiler/Compiler.csproj
@@ -41,8 +41,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\EnterpriseLibrary.Logging.6.0.1304.0\lib\NET45\Microsoft.Practices.EnterpriseLibrary.Logging.dll</HintPath>
     </Reference>
-    <Reference Include="PapyrusCompilerWrapper">
-      <HintPath>D:\Program Files (x86)\Steam\steamapps\common\Skyrim\Papyrus Compiler\PapyrusCompilerWrapper.dll</HintPath>
+    <Reference Include="PapyrusCompilerWrapper, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\PapyrusCompilerWrapper.1.0.0\lib\portable-net45+win+wpa81\PapyrusCompilerWrapper.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Compiler/Compiler.csproj
+++ b/Compiler/Compiler.csproj
@@ -41,9 +41,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\EnterpriseLibrary.Logging.6.0.1304.0\lib\NET45\Microsoft.Practices.EnterpriseLibrary.Logging.dll</HintPath>
     </Reference>
-    <Reference Include="PCompiler">
-      <HintPath>D:\Program Files (x86)\Steam\steamapps\common\Skyrim\Papyrus Compiler\PCompiler.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="PapyrusCompilerWrapper">
+      <HintPath>D:\Program Files (x86)\Steam\steamapps\common\Skyrim\Papyrus Compiler\PapyrusCompilerWrapper.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Compiler/CompilerFactory.cs
+++ b/Compiler/CompilerFactory.cs
@@ -190,7 +190,7 @@ namespace SkyrimCompileHelper.Compiler
         /// <summary>Compiles a single script file into the corresponding binary and assembly representation.</summary>
         private void CompilerThread()
         {
-            var compiler = new PapyrusCompiler
+            IPapyrusCompiler compiler = new PapyrusCompiler
             {
                 Debug = this.Debug,
                 Quiet = this.Quiet,

--- a/Compiler/ICompilerFactory.cs
+++ b/Compiler/ICompilerFactory.cs
@@ -13,6 +13,8 @@ namespace SkyrimCompileHelper.Compiler
 {
     using System.Collections.Generic;
 
+    using PapyrusCompiler;
+
     /// <summary>Provides the interface to the Papyrus compiler.</summary>
     public interface ICompilerFactory
     {
@@ -32,7 +34,7 @@ namespace SkyrimCompileHelper.Compiler
         bool Optimize { get; set; }
 
         /// <summary>Gets or sets the assembly options.</summary>
-        string AssemblyOptions { get; set; }
+        AssemblyOption AssemblyOptions { get; set; }
 
         /// <summary>Gets or sets the file to be compiled.</summary>
         /// <remarks>If <see cref="All"/> is set to true, this property must point to a directory.</remarks>

--- a/Compiler/packages.config
+++ b/Compiler/packages.config
@@ -2,4 +2,5 @@
 <packages>
   <package id="EnterpriseLibrary.Common" version="6.0.1304.0" targetFramework="net45" />
   <package id="EnterpriseLibrary.Logging" version="6.0.1304.0" targetFramework="net45" />
+  <package id="PapyrusCompilerWrapper" version="1.0.0" targetFramework="net45" />
 </packages>

--- a/SkyrimCompileHelper.sln
+++ b/SkyrimCompileHelper.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+VisualStudioVersion = 12.0.40629.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SkyrimCompileHelper", "SkyrimCompileHelper\SkyrimCompileHelper.csproj", "{8E34EFD1-8228-490A-AB01-FB94160938BF}"
 EndProject

--- a/SkyrimCompileHelper/ViewModels/SolutionViewModel.cs
+++ b/SkyrimCompileHelper/ViewModels/SolutionViewModel.cs
@@ -242,7 +242,7 @@ namespace SkyrimCompileHelper.ViewModels
                 Quiet = this.CompilerQuiet,
                 Debug = this.CompilerDebug,
                 Optimize = this.CompilerOptimize,
-                AssemblyOptions = this.SelectedAssemblyOption
+                // AssemblyOptions = this.SelectedAssemblyOption
             };
 
             int build = Convert.ToInt32(string.IsNullOrEmpty(this.Version.Build) ? "0" : this.Version.Build) + 1;
@@ -297,6 +297,7 @@ namespace SkyrimCompileHelper.ViewModels
             }
 
             // Move the compiled files to the ModOrganizer Folder
+            // Bug: Needs folder check
             IEnumerable<string> sourceFiles = Directory.GetFiles(Path.Combine(this.SolutionPath, "bin", this.SelectedConfiguration.Name));
 
             string destinationFolder = Path.Combine(this.settingsRepository.Read()["ModOrganizerPath"].ToString(), "mods", this.SolutionName);
@@ -318,7 +319,7 @@ namespace SkyrimCompileHelper.ViewModels
         }
 
         /// <summary>Saves the selected solution to the solution repository.</summary>
-        private void SaveSolution()
+        public void SaveSolution()
         {
             IDictionaryRange<string, Solution> solutions = new DictionaryRange<string, Solution>
             {

--- a/SkyrimCompileHelper/Views/SolutionView.xaml
+++ b/SkyrimCompileHelper/Views/SolutionView.xaml
@@ -64,7 +64,7 @@
                  Grid.Row="3"
                  Grid.Column="0"
                  Grid.ColumnSpan="2"
-                 Margin="0,0,0,3" 
+                 Margin="0,0,0,3"
                  cal:Message.Attach="[Event LostFocus] = [Action SaveSolution]"/>
 
         <Button x:Name="OpenSolutionFolder"


### PR DESCRIPTION
The compiler helper should use the compiler wrapper, so it can be built with AppVeyor or other CI systems.
